### PR TITLE
Install the repacked libmpg123 source tarball from chocopkg-mirrors

### DIFF
--- a/pkgdef/libmpg123.sh
+++ b/pkgdef/libmpg123.sh
@@ -1,7 +1,8 @@
 description "Fast console MPEG Audio Player and decoder library"
 check_library mpg123
+# We repack the source tarball since it is only available in tar.bz2 format:
 variant stable fetch_download \
-    https://www.mpg123.de/download/mpg123-1.25.13.tar.bz2 \
-    90306848359c793fd43b9906e52201df18775742dc3c81c06ab67a806509890a
+    $CHOCPKG_MIRRORS/mpg123-1.25.13.tar.gz \
+    0bf1a85129fc3faf6a84eaf874d8eda876a15774e0ebb801aa0ab9f29508cf89
 build_autotools
 


### PR DESCRIPTION
We repack the source tarball since it is only available in tar.bz2 format.