### PR TITLE
Update SDL_mixer to version 2.6.3

### DIFF
--- a/pkgdef/SDL2_mixer.sh
+++ b/pkgdef/SDL2_mixer.sh
@@ -11,17 +11,17 @@ variant latest fetch_git $GIT_URL SDL2
 
 # Disable dependencies on external libraries for sound file formats:
 config_options="
-    --disable-music-mod --disable-music-flac-shared
-    --disable-music-ogg-shared
+    --disable-music-mod --disable-music-flac-libflac-shared
+    --disable-music-ogg-vorbis-shared --disable-music-ogg-tremor-shared
     --disable-music-mp3-mpg123-shared
 "
 
 # ...except ones we have installed:
-if ! chocpkg installed ${PACKAGE_TYPE}:flac; then
-    config_options+=" --disable-music-flac"
+if chocpkg installed ${PACKAGE_TYPE}:flac; then
+    config_options+=" --enable-music-flac-libflac --disable-music-flac-drflac"
 fi
-if ! chocpkg installed ${PACKAGE_TYPE}:libogg; then
-    config_options+=" --disable-music-ogg"
+if chocpkg installed ${PACKAGE_TYPE}:libogg; then
+    config_options+=" --enable-music-ogg-vorbis --disable-music-ogg-stb"
 fi
 
 # FluidSynth, if we have it.
@@ -32,11 +32,7 @@ else
 fi
 
 if chocpkg installed ${PACKAGE_TYPE}:libmpg123; then
-    config_options+=" --enable-music-mp3 --disable-music-mp3-mad-gpl --enable-music-mp3-mpg123"
-elif chocpkg installed ${PACKAGE_TYPE}:libmad; then
-    config_options+=" --enable-music-mp3 --enable-music-mp3-mad-gpl"
-else
-    config_options+=" --disable-music-mp3 --disable-music-mp3-mad-gpl"
+    config_options+=" --enable-music-mp3-mpg123 --disable-music-mp3-drmp3"
 fi
 
 build_autotools $config_options

--- a/pkgdef/SDL2_mixer.sh
+++ b/pkgdef/SDL2_mixer.sh
@@ -3,10 +3,10 @@ dependencies SDL2
 check_pkgconfig SDL2_mixer
 
 variant stable fetch_download \
-    https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.6.2/SDL2_mixer-2.6.2.tar.gz \
-    8cdea810366decba3c33d32b8071bccd1c309b2499a54946d92b48e6922aa371
+    https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.6.3/SDL2_mixer-2.6.3.tar.gz \
+    7a6ba86a478648ce617e3a5e9277181bc67f7ce9876605eea6affd4a0d6eea8f
 GIT_URL=https://github.com/libsdl-org/SDL_mixer.git
-variant stable_git fetch_git $GIT_URL release-2.6.2
+variant stable_git fetch_git $GIT_URL release-2.6.3
 variant latest fetch_git $GIT_URL SDL2
 
 # Disable dependencies on external libraries for sound file formats:


### PR DESCRIPTION
In addition to bumping to the latest release, this also updates the configure options. The previous ones were not correct for 2.6.x SDL_mixer.